### PR TITLE
[FIX] DEV-1752: React Partner Widget fails to initialize with Server-Side rendering

### DIFF
--- a/entrypoints/production.js
+++ b/entrypoints/production.js
@@ -1,0 +1,12 @@
+import { withStyleLoading } from '../src/hocs';
+
+import { StockLevelEnum as STOCK_LEVEL_ENUM } from '../src/utils';
+
+// Here we loads widgets without styles
+import UnstyledWidget from '../src/widgets/defaultWidget';
+
+// Here we apply style loader HOC to widgets
+const Widget = withStyleLoading(UnstyledWidget);
+
+export default Widget;
+export { Widget, STOCK_LEVEL_ENUM };

--- a/entrypoints/storybook.js
+++ b/entrypoints/storybook.js
@@ -1,0 +1,13 @@
+// Import styles of all components.
+// It will be handled by style-loader webpack plugin.
+import '../src/styles/index.css';
+
+import DefaultWidget from '../src/widgets/defaultWidget';
+import { StockLevelEnum as STOCK_LEVEL_ENUM } from '../src/utils';
+
+export { DefaultWidget, STOCK_LEVEL_ENUM };
+export * from '../src/components';
+export * from '../src/icons';
+export * from '../src/services';
+export * from '../src/translations';
+export * from '../src/utils';

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "postcss-initial": "^3.0.0",
     "precss": "^4.0.0",
     "prettier": "^1.16.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
     "react-hot-loader": "^4.6.3",
     "semantic-release": "^15.13.3",
     "semantic-release-cli": "^4.1.0",
@@ -70,12 +73,13 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "fetch-ponyfill": "^6.0.2",
+    "insert-css": "^2.0.0",
     "pinkie-promise": "^2.0.1",
     "query-string": "^6.2.0"
   },
   "peerDependencies": {
-    "classnames": "^2.2.6",
     "prop-types": "^15.6.2",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,3 @@
-import '../styles/index.css';
-
 import Button, { LinkButton } from './button';
 import ButtonText from './buttonText';
 import Container from './container';

--- a/src/hocs/index.js
+++ b/src/hocs/index.js
@@ -1,0 +1,3 @@
+import withStyleLoading from './withStyleLoading';
+
+export { withStyleLoading };

--- a/src/hocs/withStyleLoading.jsx
+++ b/src/hocs/withStyleLoading.jsx
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import insertCss from 'insert-css';
+
+import style from '../styles/index.css';
+
+/**
+ * withStyleLoading
+ * This HOC only using in production in order to inject library styles on component mount
+ * @param {*} EnhancedComponent
+ * @returns HOC
+ */
+function withStyleLoading(EnhancedComponent) {
+    class StyleLoadingHOC extends Component {
+        constructor(props) {
+            super(props);
+
+            this.state = {
+                isInitialised: false,
+            };
+        }
+
+        componentDidMount() {
+            // This plugin will inject cssString
+            // to style tag at the top of document head
+            insertCss(style.toString(), {
+                prepend: true,
+            });
+
+            this.setState({
+                isInitialised: true,
+            });
+        }
+
+        render() {
+            const { isInitialised } = this.state;
+
+            if (!isInitialised) {
+                return null;
+            }
+
+            return <EnhancedComponent {...this.props} />;
+        }
+    }
+
+    return StyleLoadingHOC;
+}
+
+export default withStyleLoading;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,0 @@
-import Widget from './widgets/defaultWidget';
-
-import { StockLevelEnum as STOCK_LEVEL_ENUM } from './utils';
-
-export default Widget;
-export { Widget, STOCK_LEVEL_ENUM };

--- a/stories/pages/button.jsx
+++ b/stories/pages/button.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Button } from '../../src/components';
-import { GroverIcon } from '../../src/icons';
+import { Button, GroverIcon } from '../../entrypoints/storybook';
 
 export default function init() {
     storiesOf('Button', module)

--- a/stories/pages/price.jsx
+++ b/stories/pages/price.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react';
 
-import { Price, DiscountPrice } from '../../src/components';
+import { Price, DiscountPrice } from '../../entrypoints/storybook';
 
 export default function init() {
     storiesOf('Price', module)

--- a/stories/pages/widget.jsx
+++ b/stories/pages/widget.jsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Widget } from '../../src/components';
-import DefaultWidget from '../../src';
-import { StockLevelEnum } from '../../src/utils';
+import {
+    Widget,
+    DefaultWidget,
+    STOCK_LEVEL_ENUM,
+} from '../../entrypoints/storybook';
 
 export default function init() {
     storiesOf('Partners widget', module)
@@ -59,7 +61,7 @@ export default function init() {
             <DefaultWidget
                 accessToken="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdG9yZV9jb2RlIjoibWVkaWFtYXJrdCJ9.bm1niEepZwp2PgvNj9PGxyIpYD0MRF6X1SOOS5ehDxY"
                 articleId="123123123"
-                stockEnumerated={StockLevelEnum.medium}
+                stockEnumerated={STOCK_LEVEL_ENUM.medium}
                 eans={['12345', '123456', '12345667']}
                 deliveryDate="2019-08-02"
                 moreInformationCallback={action(

--- a/webpack/paths.js
+++ b/webpack/paths.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+    entrypoints: path.resolve(__dirname, '../entrypoints'),
     source: path.resolve(__dirname, '../src'),
     static: path.resolve(__dirname, '../static'),
     output: path.resolve(__dirname, '../build'),

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -14,13 +14,16 @@ const variables = require('./variables');
 module.exports = {
     mode: 'production',
     entry: {
-        package: [require.resolve(path.join(paths.source, 'index.js'))],
+        package: [
+            require.resolve(path.join(paths.entrypoints, 'production.js')),
+        ],
     },
     output: {
         filename: 'index.js',
         path: paths.output,
         publicPath: paths.static,
         libraryTarget: 'umd',
+        globalObject: 'this',
     },
     devtool: 'source-map',
     resolve: {
@@ -42,15 +45,6 @@ module.exports = {
             {
                 test: /\.(scss|css)$/,
                 use: [
-                    {
-                        loader: require.resolve('style-loader'),
-                        options: {
-                            insertAt: 'top',
-                            singleton: true,
-                            sourceMap: false,
-                            hmr: false,
-                        },
-                    },
                     {
                         loader: require.resolve('css-loader'),
                         options: {

--- a/webpack/webpack.config.storybook.js
+++ b/webpack/webpack.config.storybook.js
@@ -13,7 +13,9 @@ const variables = require('./variables');
 
 module.exports = {
     entry: {
-        package: [require.resolve(path.join(paths.source, 'index.js'))],
+        package: [
+            require.resolve(path.join(paths.entrypoints, 'storybook.js')),
+        ],
     },
     devtool: 'eval-source-map',
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,7 +3759,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -6905,6 +6905,11 @@ inquirer@^6.0.0, inquirer@^6.1.0, inquirer@^6.2.0:
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
     through "^2.3.6"
+
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+  integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
 
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.2.0"
@@ -10878,6 +10883,15 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 property-expr@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
@@ -11142,6 +11156,16 @@ react-dom@^16.6.3, react-dom@^16.7.0:
     prop-types "^15.6.2"
     scheduler "^0.12.0"
 
+react-dom@^16.8.3:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
+  integrity sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.3"
+
 react-error-overlay@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.2.tgz#888957b884d4b25b083a82ad550f7aad96585394"
@@ -11180,6 +11204,11 @@ react-inspector@^2.3.0:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
     prop-types "^15.6.1"
+
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -11254,6 +11283,16 @@ react@^16.6.3, react@^16.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.12.0"
+
+react@^16.8.3:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
+  integrity sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.3"
 
 read-cmd-shim@^1.0.1, read-cmd-shim@~1.0.1:
   version "1.0.1"
@@ -11934,6 +11973,14 @@ scheduler@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
   integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
+  integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
### Changes
The issue was related to `style-loader` webpack plugin which was trying to inject `style` tag to the head right in the import, but of course, was failed in SSR. I replaced `style-loader` with `insert-css` which do the same but it's more lightweight. Also I added the production HOC which loads styles on component mount.

### Ticket
https://byebuyglobaloperations.atlassian.net/browse/DEV-1752