### PR TITLE
[FIX] fix promotion price field

### DIFF
--- a/src/utils/mappers.js
+++ b/src/utils/mappers.js
@@ -2,7 +2,7 @@ export function mapApiRentalPlan(apiRentalPlan) {
     const {
         id,
         price,
-        promotionPrice,
+        promotion_price: promotionPrice,
         cheapest,
         description,
         minimum_term_months: minimumTermMonths,


### PR DESCRIPTION
I found an issue when we're fetching `promotionPrice` instead of `promotion_price` from the API data.